### PR TITLE
feat: Add test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install .[dev]
 
-    - name: Test with unittest
+    - name: Test with pytest
       run: |
-        python -m unittest discover -s hotplots/_test -p "*_test.py"
+        coverage run -m pytest
+        coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # WIP - Hotplots - Chia Plots Archiving Program
 
 [![Python CI](https://github.com/cciollaro/hotplots/actions/workflows/ci.yml/badge.svg)](https://github.com/cciollaro/hotplots/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cciollaro/hotplots/branch/main/graph/badge.svg)](https://codecov.io/gh/cciollaro/hotplots)
 
-Hotplots is an extensible, flexible, and well-tested chia plot archiving program. Whether moving plots to locally attached drives, or to your harvester machine, hotplots will choose which plotfile to move, where to move it to, and whether or not to replace an existing   
+Hotplots is an extensible, flexible, and well-tested chia plot archiving program. Whether moving plots to locally attached drives, or to your harvester machine, hotplots will choose which plotfile to move, where to move it to, and whether or not to replace an existing
 
 Hotplots can be used to fill up all of your existing drives, and then if configured to do so, it can start replacing plots, for example replacing non-portable (pool) plots with newer portable plots. It can also replace based on the k-value of your plots, should there ever be a time when you want to or need to upgrade to k=33. 
 
@@ -37,7 +38,7 @@ python3 -m venv venv
 3. Install the project in editable mode.
 
 ```
-pip install -e .
+pip install -e .[dev]
 ```
 
 Note: On Debian-based systems, you may need to install some system-level dependencies first:
@@ -59,7 +60,7 @@ cp config-example.yaml config.yaml
 To run the tests, first activate the virtual environment, then run the following command:
 
 ```
-python3 -m unittest discover -s hotplots/_test -p "*_test.py"
+pytest
 ```
 
 ## Running in the background

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,14 @@ dependencies = [
 [project.scripts]
 hotplots = "hotplots.main:main"
 
+[project.optional-dependencies]
+dev = [
+    "coverage",
+    "pytest",
+]
+
 [tool.black]
 line-length = 120
+
+[tool.coverage.run]
+source = ["hotplots"]


### PR DESCRIPTION
- Add `pytest` and `coverage` as dev dependencies.
- Configure `coverage` to only measure the `hotplots` package.
- Update the CI workflow to run tests with `pytest` and `coverage`, and upload the report to Codecov.
- Add a Codecov badge to the `README.md`.
- Update the testing instructions in the `README.md`.

Note: A `CODECOV_TOKEN` secret must be added to the repository settings for the Codecov action to work.