### PR TITLE
Use valid shell for sshd test container

### DIFF
--- a/docker/sshd/Dockerfile
+++ b/docker/sshd/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add openssh \
     && sed -i 's/^#?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config \
     && ssh-keygen -A
 
-RUN adduser -D -s /bin/bash sshuser \
+RUN adduser -D -s /bin/sh sshuser \
     && echo "sshuser:password" | chpasswd
 
 RUN mkdir -p /home/sshuser/.ssh \


### PR DESCRIPTION
## Summary
- use `/bin/sh` as login shell in sshd Dockerfile so password authentication works

## Testing
- `docker compose exec -T hotplots python -m pytest hotplots/_test/integration/docker_integration_test.py` *(fails: unknown shorthand flag: 'T' in -T)*

------
https://chatgpt.com/codex/tasks/task_e_68974ecb0a40832dac290f52aeb11f1f