### PR TITLE
Support key-based SSH for remote transfers

### DIFF
--- a/docker/sshd/Dockerfile
+++ b/docker/sshd/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add openssh \
     && sed -i 's/^#?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config \
     && ssh-keygen -A
 
-RUN adduser -D -s /bin/bash sshuser \
+RUN adduser -D -s /bin/sh sshuser \
     && echo "sshuser:password" | chpasswd
 
 RUN mkdir -p /home/sshuser/.ssh \

--- a/hotplots/_test/integration/docker_integration_test.py
+++ b/hotplots/_test/integration/docker_integration_test.py
@@ -98,10 +98,11 @@ class DockerIntegrationTest(HotplotsIntegrationTestBase):
                     "max_concurrent_outbound_transfers": 1,
                     "hosts": [
                         {
-                            "address": self.ssh_host,
+                            "hostname": self.ssh_host,
                             "port": self.ssh_port,
                             "username": self.ssh_user,
                             "key_path": str(self.ssh_key_path),
+                            "max_concurrent_inbound_transfers": 1,
                             "drives": [
                                 {
                                     "path": str(self.target_path_on_remote),

--- a/hotplots/hotplots_config.py
+++ b/hotplots/hotplots_config.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass(frozen=True)
@@ -70,6 +70,7 @@ class RemoteHostConfig:
     port: int
     max_concurrent_inbound_transfers: int
     drives: List[TargetDriveConfig]
+    key_path: Optional[str] = None
 
     def is_local(self):
         return False

--- a/hotplots/hotplots_io.py
+++ b/hotplots/hotplots_io.py
@@ -112,11 +112,17 @@ class HotplotsIO:
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             resolved_ip = socket.gethostbyname(remote_host_config.hostname)
-            client.connect(
-                resolved_ip,
+            connect_args = dict(
                 port=remote_host_config.port,
-                username=remote_host_config.username
+                username=remote_host_config.username,
             )
+            if remote_host_config.key_path:
+                connect_args.update(
+                    pkey=paramiko.RSAKey.from_private_key_file(remote_host_config.key_path),
+                    allow_agent=False,
+                    look_for_keys=False,
+                )
+            client.connect(resolved_ip, **connect_args)
 
             sftp = client.open_sftp()
             target_drive_infos = []
@@ -206,11 +212,17 @@ class HotplotsIO:
                 resolved_ip = socket.gethostbyname(hot_plot_target_drive.host_config.hostname)
                 sftp = None
                 try:
-                    client.connect(
-                        resolved_ip,
+                    connect_args = dict(
                         port=hot_plot_target_drive.host_config.port,
-                        username=hot_plot_target_drive.host_config.username
+                        username=hot_plot_target_drive.host_config.username,
                     )
+                    if hot_plot_target_drive.host_config.key_path:
+                        connect_args.update(
+                            pkey=paramiko.RSAKey.from_private_key_file(hot_plot_target_drive.host_config.key_path),
+                            allow_agent=False,
+                            look_for_keys=False,
+                        )
+                    client.connect(resolved_ip, **connect_args)
 
                     sftp = client.open_sftp()
 


### PR DESCRIPTION
## Summary
- add optional `key_path` to remote host config
- use provided private key for remote target discovery and transfers
- configure docker integration test with hostname and key path

## Testing
- `docker compose exec -T hotplots python -m pytest hotplots/_test/integration/docker_integration_test.py` *(fails: command not found: docker)*
- `python -m pytest hotplots/_test/integration/docker_integration_test.py` *(fails: socket.gaierror: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68974ecb0a40832dac290f52aeb11f1f